### PR TITLE
Update golangci-lint setup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/dnsc
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+linters:
+  enable:
+    - dogsled
+    - goimports
+    - gosec
+    - stylecheck
+    - goconst
+    - depguard
+    - prealloc
+    - misspell
+    - maligned
+    - dupl
+    - unconvert
+    - gofmt
+    - golint
+    - gocritic
+    - scopelint

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ OUTPUTDIR 				= release_assets
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
 VERSION 				= $(shell git describe --always --long --dirty)
 
+# https://github.com/golangci/golangci-lint#install
+# https://github.com/golangci/golangci-lint/releases/latest
+GOLANGCI_LINT_VERSION		= v1.25.1
+
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
 BUILDCMD				=	go build -a -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
@@ -63,8 +67,12 @@ lintinstall:
 	@echo "Explicitly enabling Go modules mode"
 	@export GO111MODULE="on"
 	go get golang.org/x/lint/golint
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get honnef.co/go/tools/cmd/staticcheck
+
+	@echo Installing golangci-lint ${GOLANGCI_LINT_VERSION} per official binary installation docs ...
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+	golangci-lint --version
+
 	@echo "Finished updating linting tools"
 
 .PHONY: linting
@@ -86,19 +94,7 @@ linting:
 	@golint -set_exit_status ./...
 
 	@echo "Running golangci-lint ..."
-	@golangci-lint run \
-		-E goimports \
-		-E gosec \
-		-E stylecheck \
-		-E goconst \
-		-E depguard \
-		-E prealloc \
-		-E misspell \
-		-E maligned \
-		-E dupl \
-		-E unconvert \
-		-E golint \
-		-E gocritic
+	@golangci-lint run
 
 	@echo "Running staticcheck ..."
 	@staticcheck ./...


### PR DESCRIPTION
## Changes

- Move linter settings to external config file
- Replace build-from-source installation process with official binary installation process
- Use latest v1.25.1 version
- Enable `scopelint` linter
- Enable `dogsled` linter
- Enable `gofmt` linter

## References

- fixes #27
- fixes #32
- fixes #33
- fixes #34
