### PR TITLE
Record and report nameserver response time

### DIFF
--- a/dqrs/queryresponse.go
+++ b/dqrs/queryresponse.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -42,6 +43,10 @@ type DNSQueryResponse struct {
 	// Error records whether an error occurred during any part of performing a
 	// query
 	QueryError error
+
+	// ResponseTime is a measurement of how long it takes a remote DNS server
+	// to respond to our query with an answer.
+	ResponseTime time.Duration
 }
 
 // DNSQueryResponses is a collection of DNS query responses. Intended for
@@ -174,8 +179,11 @@ func PerformQuery(query string, server string, qType uint16) DNSQueryResponse {
 		RequestedRecordType: qType,
 	}
 
+	queryStart := time.Now()
+
 	// Perform UDP-based query using default settings
 	in, err := dns.Exchange(&msg, server+":53")
+	dnsQueryResponse.ResponseTime = time.Since(queryStart)
 	if err != nil {
 		dnsQueryResponse.QueryError = err
 		return dnsQueryResponse

--- a/dqrs/summary.go
+++ b/dqrs/summary.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 )
 
 // PrintSummary generates a table of all collected DNS query results
@@ -28,12 +29,12 @@ func (dqrs DNSQueryResponses) PrintSummary() {
 
 	// Header row in output
 	fmt.Fprintf(w,
-		"Server\tQuery\tType\tAnswers\tTTL\t\n")
+		"Server\tWait\tQuery\tType\tAnswers\tTTL\t\n")
 
 	// Separator row
 	// TODO: I'm sure this can be handled better
 	fmt.Fprintln(w,
-		"---\t---\t---\t---\t---\t")
+		"---\t---\t---\t---\t---\t---\t")
 
 	for _, item := range dqrs {
 
@@ -46,8 +47,9 @@ func (dqrs DNSQueryResponses) PrintSummary() {
 		// instead of attempting to show real results
 		if item.QueryError != nil {
 			fmt.Fprintf(w,
-				"%s\t%s\t%s\t%s\t%s\t\n",
+				"%s\t%s\t%s\t%s\t%s\t%s\t\n",
 				item.Server,
+				item.ResponseTime.Round(time.Millisecond),
 				item.Query,
 				rrString,
 				item.QueryError.Error(),
@@ -60,8 +62,9 @@ func (dqrs DNSQueryResponses) PrintSummary() {
 		item.SortRecordsAsc()
 
 		fmt.Fprintf(w,
-			"%s\t%s\t%s\t%s\t%s\t\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t\n",
 			item.Server,
+			item.ResponseTime.Round(time.Millisecond),
 			item.Query,
 			rrString,
 			item.Records(),


### PR DESCRIPTION
Of note:

- Display the value in a new `Wait` column.
- Round the value to milliseconds.

I think that `ResponseTime` would have been more descriptive, but the current display layout is already fairly cramped, so I opted for something shorter instead.

fixes #22