### PR TITLE
Increase default timeout, allow custom override

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Submit query against a list of DNS servers and display summary of results
   - [Features](#features)
     - [Current](#current)
     - [Planned](#planned)
+  - [Changelog](#changelog)
+  - [Requirements](#requirements)
+  - [How to install it](#how-to-install-it)
   - [Configuration](#configuration)
     - [Precedence](#precedence)
     - [Command-line arguments](#command-line-arguments)
@@ -64,6 +67,8 @@ repeat use.
 - User configurable logging levels
 
 - User configurable logging format
+
+- User configurable query timeout
 
 ### Planned
 
@@ -155,6 +160,7 @@ command-line flags and use the configuration file for the other settings.
 | `ll`, `log-level`          | No       | `info`         | No      | `fatal`, `error`, `warn`, `info`, `debug`  | Log message priority filter. Log messages with a lower level are ignored.                                                                                     |
 | `lf`, `log-format`         | No       | `text`         | No      | `cli`, `json`, `logfmt`, `text`, `discard` | Use the specified `apex/log` package "handler" to output log messages in that handler's format.                                                               |
 | `t`, `type`                | No       | `A`            | **Yes** | `A`, `AAAA`, `MX`, `CNAME`                 | DNS query type to use when submitting a DNS query to each provided server. This flag may be repeated for each additional DNS record type you wish to request. |
+| `to`, `timeout`            | No       | `10`           | No      | *any positive whole number*                | Maximum number of seconds allowed for a DNS query to take before timing out.                                                                                  |
 
 ### Configuration file
 
@@ -172,6 +178,7 @@ settings.
 | `log-level`         | `log_level`              |                                                                                    |
 | `log-format`        | `log_format`             |                                                                                    |
 | `type`              | `dns_request_types`      | [Multi-line array](https://github.com/toml-lang/toml#user-content-array)           |
+| `timeout`           | `timeout`                |                                                                                    |
 
 The [`config.example.toml`](config.example.toml) file is intended as a
 starting point for your own `config.toml` configuration file and attempts to
@@ -461,3 +468,6 @@ authors of both!
   - <https://developers.google.com/speed/public-dns>
   - <https://www.opendns.com/setupguide/>
   - <https://blog.cloudflare.com/announcing-1111/>
+
+- Definitions
+  - <https://www.cloudflare.com/learning/cdn/glossary/round-trip-time-rtt/>

--- a/cmd/dnsc/main.go
+++ b/cmd/dnsc/main.go
@@ -45,6 +45,7 @@ func main() {
 	// Get a list of all record types that we should request when submitting
 	// DNS queries
 	queryTypes := cfg.QueryTypes()
+	queryTimeout := cfg.Timeout()
 
 	expectedResponses := len(queryTypes) * len(cfg.Servers())
 
@@ -82,7 +83,7 @@ func main() {
 				}
 				log.Debugf("Submitting query for %q of type %q to %q",
 					query, rrString, server)
-				resultsChan <- dqrs.PerformQuery(query, server, rrType)
+				resultsChan <- dqrs.PerformQuery(query, server, rrType, queryTimeout)
 			}
 		}(server, cfg.Query(), queryTypes, resultsChan)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -69,3 +69,6 @@ log_format = "cli"
 # Specifying a static/hard-coded query here is not enabled by default, but
 # could prove useful in some situations.
 # query = "www.yahoo.com"
+
+# Maximum number of seconds allowed for a DNS query to take before timing out.
+# timeout = 10

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ const (
 	configFileFlagHelp      = "Full path to TOML-formatted configuration file. See config.example.toml for a starter template."
 	dnsServerFlagHelp       = "DNS server to submit query against. This flag may be repeated for each additional DNS server to query."
 	dnsRequestTypeFlagHelp  = "DNS query type to use when submitting DNS queries. The default is the 'A' query type. This flag may be repeated for each additional DNS record type you wish to request."
+	dnsTimeoutFlagHelp      = "Maximum number of seconds allowed for a DNS query to take before timing out."
 )
 
 // Default flag settings if not overridden by user input
@@ -50,6 +51,12 @@ const (
 	defaultIgnoreDNSErrors       bool   = false
 	defaultConfigFileName        string = "config.toml"
 	defaultQueryType             string = "A"
+
+	// the default timeout is set by the `miekg/dns.dnsTimeout` value, which
+	// at the time of this writing is 2 seconds. we override with our own
+	// longer default (GH-17), but allow the user to override with their own
+	// preference later.
+	defaultTimeout int = 10
 )
 
 // Log levels
@@ -190,6 +197,10 @@ type configTemplate struct {
 	// of the formats supported by the third-party leveled-logging package
 	// used by this application.
 	LogFormat string `toml:"log_format"`
+
+	// Timeout is the number of seconds allowed for a DNS query to complete
+	// before it times out.
+	Timeout int `toml:"timeout"`
 }
 
 func (c Config) String() string {

--- a/config/flags.go
+++ b/config/flags.go
@@ -25,6 +25,9 @@ func (c *Config) handleFlagsConfig() {
 	flag.Var(&c.cliConfig.QueryTypes, "t", dnsRequestTypeFlagHelp+" (shorthand)")
 	flag.Var(&c.cliConfig.QueryTypes, "type", dnsRequestTypeFlagHelp)
 
+	flag.IntVar(&c.cliConfig.Timeout, "to", defaultTimeout, dnsTimeoutFlagHelp+" (shorthand)")
+	flag.IntVar(&c.cliConfig.Timeout, "timeout", defaultTimeout, dnsTimeoutFlagHelp)
+
 	flag.StringVar(&c.configFile, "cf", "", configFileFlagHelp+" (shorthand)")
 	flag.StringVar(&c.configFile, "config-file", "", configFileFlagHelp)
 

--- a/config/getters.go
+++ b/config/getters.go
@@ -8,6 +8,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/apex/log"
 )
 
@@ -87,6 +89,24 @@ func (c Config) QueryTypes() []string {
 		log.Debugf("Requested record types not specified, using default: %q",
 			defaultQueryType)
 		return []string{defaultQueryType}
+	}
+}
+
+// Timeout returns the user-provided choice of what timeout value to use for
+// DNS queries. If not set, returns the default value for our application.
+func (c Config) Timeout() time.Duration {
+
+	// FIXME: Initial implementation for GH-17; will need to be revisited
+	// alongside the work on GH-10.
+	switch {
+	case c.cliConfig.Timeout != 0:
+		return time.Duration(c.cliConfig.Timeout) * time.Second
+	case c.fileConfig.Timeout != 0:
+		return time.Duration(c.fileConfig.Timeout) * time.Second
+	default:
+		log.Debugf("Requested timeout value not specified, using default: %v",
+			defaultTimeout)
+		return time.Duration(defaultTimeout) * time.Second
 	}
 }
 

--- a/dqrs/summary.go
+++ b/dqrs/summary.go
@@ -29,7 +29,7 @@ func (dqrs DNSQueryResponses) PrintSummary() {
 
 	// Header row in output
 	fmt.Fprintf(w,
-		"Server\tWait\tQuery\tType\tAnswers\tTTL\t\n")
+		"Server\tRTT\tQuery\tType\tAnswers\tTTL\t\n")
 
 	// Separator row
 	// TODO: I'm sure this can be handled better


### PR DESCRIPTION
## Changes

- Increase default timeout from 2s to 10s

- Add `-timeout` or `-to` flags to allow overriding the default 10s value with a custom value in seconds

- Use existing RTT returned by `Client.Exchange()` instead of calculating our own using `time.Since()`
  - the assumption is that the RTT value is captured "closer to the source" and will end up being more accurate than what we're capturing from outside of the responsible function call

- Change summary output column label `Wait` to `RTT` to use standard DNS/network terminology

- Update README to list new flag, new config file setting, and new default behavior

- Update example config file to list new option and default value

## References

- fixes GH-17
- refs GH-41