### PR TITLE
Enable GitHub Actions Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,4 +41,21 @@ updates:
       # Prefix all commit messages with "go.mod"
       prefix: "go.mod"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "ghaw"
 


### PR DESCRIPTION
Enable update PRs similar to the existing Go Modules setup.

refs GH-48