### PR TITLE
Fix path to Makefile generated binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Tested using:
    - for Linux
      - `make linux`
 1. Copy the applicable binary to whatever systems needs to run it
-   - if using `Makefile`: look in `/tmp/release_assets/dnsc/`
+   - if using `Makefile`: look in `/tmp/dnsc/release_assets/dnsc/`
    - if using `go build`: look in `/tmp/dnsc/`
 
 ## Configuration


### PR DESCRIPTION
## Changes

Fill in the complete path to the `Makefile` generated binary. This was intended to go in with GH-38, but better later than never?

## References

- fixes GH-68
- refs GH-30
- refs GH-38
- refs atc0005/todo#10
