### PR TITLE
golangci-lint | Disable default exclusions in cfg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,15 @@
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.
 
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
 linters:
   enable:
     - dogsled


### PR DESCRIPTION
Add explicit config settings to disable default exclusions

This same config change will need to be pushed to all other
repos where I am using this config set.

Note to self: Docker container sooner than later perhaps?

- refs atc0005/todo#29
- refs atc0005/todo#22