### PR TITLE
Fix misc linting errors

### DIFF
--- a/dqrs/summary.go
+++ b/dqrs/summary.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"text/tabwriter"
 	"time"
+
+	"github.com/apex/log"
 )
 
 // PrintSummary generates a table of all collected DNS query results
@@ -73,5 +75,9 @@ func (dqrs DNSQueryResponses) PrintSummary() {
 	}
 
 	fmt.Fprintln(w)
-	w.Flush()
+
+	// TODO: Add a retry?
+	if err := w.Flush(); err != nil {
+		log.Errorf("Error flushing tabwriter: %v", err.Error())
+	}
 }


### PR DESCRIPTION
## Changes

Add missing error return value checks:

- deferred file closure
- tabwriter flush

In both cases the error is explicitly logged.

Use `filepath.Clean()` to help sanitize user input. This resolves the gosec linting issue flagged for a bare `os.Open()` against a path provided by a variable.

## References

- fixes GH-77
- fixes GH-79
- fixes GH-78