### PR TITLE
Swap out linting container, update badges

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: index.docker.io/atc0005/go-ci:go-ci-stable
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: index.docker.io/atc0005/go-ci:go-ci-stable
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
 
     steps:
       - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,15 @@ The following types of changes will be recorded in this file:
 
 ## [Unreleased]
 
-- placeholder
+### Added
+
+- Add new README badges for additional CI workflows
+
+### Changed
+
+- Swap out `go-ci-stable` image tag for `go-ci-lint-only`
+  - the `go-ci-lint-only` image is substantially smaller and *should* result
+    in faster spin-up times
 
 ## [v0.3.0] - 2020-07-30
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Submit query against a list of DNS servers and display summary of results
 [![GoDoc](https://godoc.org/github.com/atc0005/dnsc?status.svg)](https://godoc.org/github.com/atc0005/dnsc)
 ![Validate Codebase](https://github.com/atc0005/dnsc/workflows/Validate%20Codebase/badge.svg)
 ![Validate Docs](https://github.com/atc0005/dnsc/workflows/Validate%20Docs/badge.svg)
+![Lint and Build using Makefile](https://github.com/atc0005/dnsc/workflows/Lint%20and%20Build%20using%20Makefile/badge.svg)
+![Quick Validation](https://github.com/atc0005/dnsc/workflows/Quick%20Validation/badge.svg)
 
 - [dnsc](#dnsc)
   - [Project home](#project-home)


### PR DESCRIPTION
- Add badges for recent workflows
- Swap out container used in linting-only tasks
  - slightly smaller, will hopefully speed up the process

See also `v0.1.1` release of the `atc0005/go-ci` project.