### PR TITLE
go.mod | Update Go version to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/dnsc
 
-go 1.13
+go 1.14
 
 require (
 	github.com/apex/log v1.9.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # github.com/apex/log v1.9.0
+## explicit
 github.com/apex/log
 github.com/apex/log/handlers/cli
 github.com/apex/log/handlers/discard
@@ -12,12 +13,17 @@ github.com/go-logfmt/logfmt
 # github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 github.com/kr/logfmt
 # github.com/mattn/go-colorable v0.1.6
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
 # github.com/miekg/dns v1.1.31
+## explicit
 github.com/miekg/dns
+# github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e
+## explicit
 # github.com/pelletier/go-toml v1.8.0
+## explicit
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.8.1
 github.com/pkg/errors
@@ -33,3 +39,5 @@ golang.org/x/net/ipv6
 # golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
 golang.org/x/sys/unix
 golang.org/x/sys/windows
+# gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+## explicit


### PR DESCRIPTION
- Update "oldstable" version
- go mod tidy && go mod vendor