### PR TITLE
Attempt to clarify config file load behavior

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -320,8 +320,9 @@ func NewConfig() (*Config, error) {
 	}
 
 	//
-	// Attempt to load requested config file, fallback to known alternates
-	// if user did not specify a config file
+	// Attempt to load requested config file first. If not provided or if
+	// unable to use, attempt to load config file from known alternative
+	// locations.
 	//
 
 	configFiles := make([]string, 0, 3)


### PR DESCRIPTION
Update doc comments to explicitly note that a provided path to the config file will be used first, but if there are problems or if a path isn't provided a set of known default locations for the config file will be attempted instead.