### PR TITLE
Fix misc linting issues from golangci-lint v1.31.0

### DIFF
--- a/cmd/dnsc/main.go
+++ b/cmd/dnsc/main.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	//"log"
 	"errors"
 	"flag"
 	"fmt"

--- a/config/config.go
+++ b/config/config.go
@@ -293,7 +293,7 @@ func PathExists(path string) bool {
 
 	// https://gist.github.com/mattes/d13e273314c3b3ade33f
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		//log.Println("path found")
+		// log.Println("path found")
 		return true
 	}
 
@@ -380,7 +380,7 @@ func NewConfig() (*Config, error) {
 	}
 	log.Debug("Configuration validated")
 
-	//log.Debugf("Config object: %v", config.String())
+	// log.Debugf("Config object: %v", config.String())
 
 	return &config, nil
 

--- a/dqrs/queryresponse.go
+++ b/dqrs/queryresponse.go
@@ -138,7 +138,7 @@ func (dqr DNSQueryResponse) Records() string {
 			answer = v.AAAA.String() + " (AAAA)"
 		case *dns.CNAME:
 			answer = v.Target + " (CNAME)"
-			//fmt.Println("Check *dns.CNAME type switch case stmt")
+			// fmt.Println("Check *dns.CNAME type switch case stmt")
 			// answer = v.String() + " (CNAME)"
 		case *dns.MX:
 			answer = v.Mx + " (MX)"

--- a/dqrs/summary.go
+++ b/dqrs/summary.go
@@ -19,10 +19,10 @@ import (
 // PrintSummary generates a table of all collected DNS query results
 func (dqrs DNSQueryResponses) PrintSummary() {
 	w := new(tabwriter.Writer)
-	//w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
+	// w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, '.', tabwriter.AlignRight|tabwriter.Debug)
 
 	// Format in tab-separated columns
-	//w.Init(os.Stdout, 16, 8, 8, '\t', 0)
+	// w.Init(os.Stdout, 16, 8, 8, '\t', 0)
 	w.Init(os.Stdout, 4, 4, 4, ' ', 0)
 
 	// Add some lead-in spacing to better separate any earlier log messages from


### PR DESCRIPTION
- Fix `gocritic` complaints re comment formatting
- Remove commented out stdlib log package import
  - using `apex/log` instead