### PR TITLE
Use default val consts instead of hard-coded vals

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,8 @@ const (
 	defaultDNSErrorsFatal        bool   = false
 	defaultConfigFileName        string = "config.toml"
 	defaultQueryType             string = "A"
+	defaultConfigFile            string = ""
+	defaultQuery                 string = ""
 
 	// the default timeout is set by the `miekg/dns.dnsTimeout` value, which
 	// at the time of this writing is 2 seconds. we override with our own

--- a/config/flags.go
+++ b/config/flags.go
@@ -28,7 +28,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.IntVar(&c.cliConfig.Timeout, "to", defaultTimeout, dnsTimeoutFlagHelp+" (shorthand)")
 	flag.IntVar(&c.cliConfig.Timeout, "timeout", defaultTimeout, dnsTimeoutFlagHelp)
 
-	flag.StringVar(&c.configFile, "cf", "", configFileFlagHelp+" (shorthand)")
+	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+" (shorthand)")
 	flag.StringVar(&c.configFile, "config-file", "", configFileFlagHelp)
 
 	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
@@ -37,7 +37,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "dns-errors-fatal", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp)
 	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "def", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp+" (shorthand)")
 
-	flag.StringVar(&c.cliConfig.Query, "query", "", queryFlagHelp)
+	flag.StringVar(&c.cliConfig.Query, "query", defaultQuery, queryFlagHelp)
 	flag.StringVar(&c.cliConfig.Query, "q", "", queryFlagHelp+" (shorthand)")
 
 	// create shorter and longer logging level flag options

--- a/config/getters.go
+++ b/config/getters.go
@@ -28,8 +28,9 @@ func (c Config) Servers() []string {
 	}
 }
 
-// Query returns the user-provided DNS server query or empty string if DNS
-// server query was not provided. CLI flag values take precedence if provided.
+// Query returns the user-provided DNS server query or the default value if
+// DNS server query was not provided. CLI flag values take precedence if
+// provided.
 func (c Config) Query() string {
 
 	switch {
@@ -38,12 +39,12 @@ func (c Config) Query() string {
 	case c.fileConfig.Query != "":
 		return c.fileConfig.Query
 	default:
-		return ""
+		return defaultQuery
 	}
 }
 
-// LogLevel returns the user-provided logging level or empty string if not
-// provided. CLI flag values take precedence if provided.
+// LogLevel returns the user-provided logging level or the default value if
+// not provided. CLI flag values take precedence if provided.
 func (c Config) LogLevel() string {
 
 	switch {
@@ -52,7 +53,7 @@ func (c Config) LogLevel() string {
 	case c.fileConfig.LogLevel != "":
 		return c.fileConfig.LogLevel
 	default:
-		return ""
+		return defaultLogLevel
 	}
 }
 
@@ -66,7 +67,7 @@ func (c Config) LogFormat() string {
 	case c.fileConfig.LogFormat != "":
 		return c.fileConfig.LogFormat
 	default:
-		return ""
+		return defaultLogFormat
 	}
 }
 


### PR DESCRIPTION
- add missing default value consts
- actually *use* default value consts

fixes atc0005/dnsc#108
refs atc0005/go-lockss#39