### PR TITLE
Disable cgo, use build tags to enable Go libc alts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,31 @@ VERSION 				= $(shell git describe --always --long --dirty)
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
 #
+# We also include additional flags in an effort to generate static binaries
+# that do not have external dependencies. As of Go 1.15 this still appears to
+# be a mixed bag, so YMMV.
+#
+# See https://github.com/golang/go/issues/26492 for more information.
+#
+# -s
+#	Omit the symbol table and debug information.
+#
+# -w
+#	Omit the DWARF symbol table.
+#
+# -tags 'osusergo,netgo'
+#	Use pure Go implementation of user and group id/name resolution.
+#	Use pure Go implementation of DNS resolver.
+#
 # -trimpath
 #	https://golang.org/cmd/go/
 #   removes all file system paths from the compiled executable, to improve
 #   build reproducibility.
-BUILDCMD				=	go build -mod=vendor -a -trimpath -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+#
+# CGO_ENABLED=0
+#	https://golang.org/cmd/cgo/
+#	explicitly disable use of cgo
+BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -a -trimpath -tags 'osusergo,netgo' -ldflags="-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
 GOCLEANCMD				=	go clean -mod=vendor ./...
 GITCLEANCMD				= 	git clean -xfd
 CHECKSUMCMD				=	sha256sum -b


### PR DESCRIPTION
By using these build tags we can generate native static binaries without dynamic linkage.

By using `CGO_ENABLED=0` we try to prevent unintentional libc dependencies from slipping in if we pull in additional dependencies in the future

fixes GH-112