### PR TITLE
Add support for SRV records

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Submit query against a list of DNS servers and display summary of results
     - [Use config file for DNS servers list and query types](#use-config-file-for-dns-servers-list-and-query-types)
     - [Specify DNS servers list via flags](#specify-dns-servers-list-via-flags)
     - [Query pointer record (PTR) using IP Address](#query-pointer-record-ptr-using-ip-address)
+    - [Query server record (SRV)](#query-server-record-srv)
     - [Force exit on first DNS error](#force-exit-on-first-dns-error)
   - [Inspiration](#inspiration)
   - [References](#references)
@@ -65,6 +66,7 @@ repeat use.
   - `AAAA`
   - `MX`
   - `PTR`
+  - `SRV`
 
 - User configurable logging levels
 
@@ -161,7 +163,7 @@ command-line flags and use the configuration file for the other settings.
 | `q`, `query`              | **Yes**  | *empty string* | No      | *any valid FQDN string*                    | Fully-qualified system to lookup from all provided DNS servers.                                                                                               |
 | `ll`, `log-level`         | No       | `info`         | No      | `fatal`, `error`, `warn`, `info`, `debug`  | Log message priority filter. Log messages with a lower level are ignored.                                                                                     |
 | `lf`, `log-format`        | No       | `text`         | No      | `cli`, `json`, `logfmt`, `text`, `discard` | Use the specified `apex/log` package "handler" to output log messages in that handler's format.                                                               |
-| `t`, `type`               | No       | `A`            | **Yes** | `A`, `AAAA`, `MX`, `CNAME`, `PTR`          | DNS query type to use when submitting a DNS query to each provided server. This flag may be repeated for each additional DNS record type you wish to request. |
+| `t`, `type`               | No       | `A`            | **Yes** | `A`, `AAAA`, `MX`, `CNAME`, `PTR`, `SRV`   | DNS query type to use when submitting a DNS query to each provided server. This flag may be repeated for each additional DNS record type you wish to request. |
 | `to`, `timeout`           | No       | `10`           | No      | *any positive whole number*                | Maximum number of seconds allowed for a DNS query to take before timing out.                                                                                  |
 
 ### Configuration file
@@ -360,6 +362,27 @@ $ dnsc --ds 8.8.8.8 --q 74.6.143.25 -t ptr
 Server     RTT    Query          Type    Answers                                                  TTL
 ---        ---    ---            ---     ---                                                      ---
 8.8.8.8    7ms    74.6.143.25    PTR     media-router-fp73.prod.media.vip.bf1.yahoo.com. (PTR)    483
+
+```
+
+### Query server record (SRV)
+
+In this example, we query for available XMPP servers for `conversations.im`.
+
+```ShellSession
+
+$ dnsc --ds 8.8.8.8 --q "_xmpp-client._tcp.conversations.im" -t srv
+
+  INFO[0000] User-specified config file not provided
+  INFO[0000] Trying to load config file "T:\\github\\dnsc\\config.toml"
+  WARN[0000] Config file "T:\\github\\dnsc\\config.toml" not found or unable to load
+  INFO[0000] Trying to load config file "C:\\Users\\adam\\AppData\\Roaming\\dnsc\\config.toml"
+  INFO[0000] Config file successfully loaded config_file=C:\Users\adam\AppData\Roaming\dnsc\config.toml
+
+
+Server     RTT      Query                                 Type    Answers                                                        TTL
+---        ---      ---                                   ---     ---                                                            ---
+8.8.8.8    113ms    _xmpp-client._tcp.conversations.im    SRV     xmpps.conversations.im. (SRV), xmpp.conversations.im. (SRV)    3599, 3599
 
 ```
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,10 @@ dns_query_types = [
     # likely to not be the case if searching other record types.
     #
     # "PTR",
+
+    # This type expects the query string to be ina  very specific format,
+    # which is likely to not be the case if searching other record types.
+    # "SRV",
 ]
 
 # Whether DNS-related errors should force this application to immediately exit.

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ const (
 	RequestTypeCNAME string = "CNAME"
 	RequestTypeMX    string = "MX"
 	RequestTypePTR   string = "PTR"
+	RequestTypeSRV   string = "SRV"
 )
 
 // 	apex/log Handlers

--- a/config/validate.go
+++ b/config/validate.go
@@ -48,6 +48,7 @@ func (c Config) Validate() error {
 		case RequestTypeCNAME:
 		case RequestTypeMX:
 		case RequestTypePTR:
+		case RequestTypeSRV:
 		default:
 			return fmt.Errorf(
 				"invalid option %q provided for request type",

--- a/dqrs/queryresponse.go
+++ b/dqrs/queryresponse.go
@@ -144,6 +144,8 @@ func (dqr DNSQueryResponse) Records() string {
 			answer = v.Mx + " (MX)"
 		case *dns.PTR:
 			answer = v.Ptr + " (PTR)"
+		case *dns.SRV:
+			answer = v.Target + " (SRV)"
 		default:
 			answer = "type unknown"
 		}


### PR DESCRIPTION
- Support querying SRV record for given query string
  - NOTE: requires very precise (but standardized) format
- Doc updates
  - Add example in README
  - Add query type to example config file, disabled by default
  - Note SRV record query support in features list, supported
    query type flag values

fixes GH-12