### PR TITLE
Use default consts instead of empty strings

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -29,7 +29,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.IntVar(&c.cliConfig.Timeout, "timeout", defaultTimeout, dnsTimeoutFlagHelp)
 
 	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+" (shorthand)")
-	flag.StringVar(&c.configFile, "config-file", "", configFileFlagHelp)
+	flag.StringVar(&c.configFile, "config-file", defaultConfigFile, configFileFlagHelp)
 
 	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
 	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
@@ -38,7 +38,7 @@ func (c *Config) handleFlagsConfig() {
 	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "def", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp+" (shorthand)")
 
 	flag.StringVar(&c.cliConfig.Query, "query", defaultQuery, queryFlagHelp)
-	flag.StringVar(&c.cliConfig.Query, "q", "", queryFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.Query, "q", defaultQuery, queryFlagHelp+" (shorthand)")
 
 	// create shorter and longer logging level flag options
 	flag.StringVar(&c.cliConfig.LogLevel, "ll", defaultLogLevel, logLevelFlagHelp+" (shorthand)")


### PR DESCRIPTION
- query string
- config file

Both flag pairs (short and long) had one entry which used
the default const for the flag, the other used an empty
string. While the result was the same (for now they both
have empty strings as the const value), this was a potential
logic bug later if the default values changed.