### PR TITLE
Implement multi-line summary output support

### DIFF
--- a/cmd/dnsc/main.go
+++ b/cmd/dnsc/main.go
@@ -83,7 +83,7 @@ func main() {
 				// Check whether the user has opted to treat errors as fatal. If
 				// so, display current summary results and exit
 				if cfg.DNSErrorsFatal() {
-					results.PrintSummary()
+					results.PrintSummary(cfg.ResultsOutput())
 					os.Exit(1)
 				}
 			}
@@ -201,7 +201,8 @@ func main() {
 		return results[i].Server < results[j].Server
 	})
 
-	// Generate summary of all collected query responses
-	results.PrintSummary()
+	// Generate summary of all collected query responses in the specified
+	// format
+	results.PrintSummary(cfg.ResultsOutput())
 
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -91,3 +91,11 @@ log_format = "cli"
 
 # Maximum number of seconds allowed for a DNS query to take before timing out.
 # timeout = 10
+
+# Specifies whether the results summary is composed of a single
+# comma-separated line of records for a query, or whether the records are
+# returned one per line.
+#
+# single-line
+# multi-line
+results_output = "multi-line"

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ const (
 	dnsRequestTypeFlagHelp = "DNS query type to use when submitting DNS queries. The default is the 'A' query type. This flag may be repeated for each additional DNS record type you wish to request."
 	dnsTimeoutFlagHelp     = "Maximum number of seconds allowed for a DNS query to take before timing out."
 	srvProtocolFlagHelp    = "Service Location (SRV) protocols associated with a given domain name as the query string. For example, \"msdcs\" can be specified as the SRV record protocol along with \"example.com\" as the query string to search DNS for \"_ldap._tcp.dc._msdcs.example.com\". This flag may be repeated for each additional SRV protocol that you wish to request records for."
+	resultsOutputFlagHelp  = "Specifies whether the results summary output is composed of a single comma-separated line of records for a query, or whether the records are returned one per line."
 )
 
 // Default flag settings if not overridden by user input
@@ -54,6 +55,7 @@ const (
 	defaultQueryType             string = "A"
 	defaultConfigFile            string = ""
 	defaultQuery                 string = ""
+	defaultResultsOutput         string = ResultsOutputMultiLine
 
 	// the default timeout is set by the `miekg/dns.dnsTimeout` value, which
 	// at the time of this writing is 2 seconds. we override with our own
@@ -85,6 +87,7 @@ const (
 )
 
 // Supported Request types
+// TODO: Duplicated in dqrs package
 const (
 	RequestTypeA     string = "A"
 	RequestTypeAAAA  string = "AAAA"
@@ -133,6 +136,13 @@ const (
 
 	// LogFormatDiscard discards all logs
 	LogFormatDiscard string = "discard"
+)
+
+// Results summary output display options
+// TODO: Duplicated in dqrs package
+const (
+	ResultsOutputSingleLine string = "single-line"
+	ResultsOutputMultiLine  string = "multi-line"
 )
 
 // multiValueFlag is a custom type that satisfies the flag.Value interface in
@@ -232,6 +242,11 @@ type configTemplate struct {
 	// used by this application.
 	LogFormat string `toml:"log_format"`
 
+	// ResultsOutput specifies whether the results summary is composed of a
+	// single comma-separated line of records for a query, or whether the
+	// records are returned one per line.
+	ResultsOutput string `toml:"results_output"`
+
 	// Timeout is the number of seconds allowed for a DNS query to complete
 	// before it times out.
 	Timeout int `toml:"timeout"`
@@ -239,13 +254,14 @@ type configTemplate struct {
 
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"cliConfig: { Servers: %v, Query: %q, LogLevel: %s, LogFormat: %s, DNSErrorsFatal: %v, QueryTypes: %v, SrvProtocols: %v}, "+
-			"fileConfig: { Servers: %v, Query: %q, LogLevel: %s, LogFormat: %s, DNSErrorsFatal: %v, QueryTypes: %v, SrvProtocols: %v}, "+
+		"cliConfig: { Servers: %v, Query: %q, LogLevel: %s, LogFormat: %s, ResultsOutput: %s, DNSErrorsFatal: %v, QueryTypes: %v, SrvProtocols: %v}, "+
+			"fileConfig: { Servers: %v, Query: %q, LogLevel: %s, LogFormat: %s, ResultsOutput: %s, DNSErrorsFatal: %v, QueryTypes: %v, SrvProtocols: %v}, "+
 			"ConfigFile: %q, ShowVersion: %t,",
 		c.cliConfig.Servers,
 		c.cliConfig.Query,
 		c.cliConfig.LogLevel,
 		c.cliConfig.LogFormat,
+		c.cliConfig.ResultsOutput,
 		c.cliConfig.DNSErrorsFatal,
 		c.cliConfig.QueryTypes,
 		c.cliConfig.SrvProtocols,
@@ -253,6 +269,7 @@ func (c Config) String() string {
 		c.fileConfig.Query,
 		c.fileConfig.LogLevel,
 		c.fileConfig.LogFormat,
+		c.fileConfig.ResultsOutput,
 		c.fileConfig.DNSErrorsFatal,
 		c.fileConfig.QueryTypes,
 		c.fileConfig.SrvProtocols,

--- a/config/flags.go
+++ b/config/flags.go
@@ -43,13 +43,14 @@ func (c *Config) handleFlagsConfig() {
 	flag.Var(&c.cliConfig.SrvProtocols, "srv-protocol", srvProtocolFlagHelp)
 	flag.Var(&c.cliConfig.SrvProtocols, "sp", srvProtocolFlagHelp+" (shorthand)")
 
-	// create shorter and longer logging level flag options
 	flag.StringVar(&c.cliConfig.LogLevel, "ll", defaultLogLevel, logLevelFlagHelp+" (shorthand)")
 	flag.StringVar(&c.cliConfig.LogLevel, "log-level", defaultLogLevel, logLevelFlagHelp)
 
-	// create shorter and longer logging format flag options
 	flag.StringVar(&c.cliConfig.LogFormat, "lf", defaultLogFormat, logFormatFlagHelp+" (shorthand)")
 	flag.StringVar(&c.cliConfig.LogFormat, "log-format", defaultLogFormat, logFormatFlagHelp)
+
+	flag.StringVar(&c.cliConfig.ResultsOutput, "ro", defaultResultsOutput, resultsOutputFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.ResultsOutput, "results-output", defaultResultsOutput, resultsOutputFlagHelp)
 
 	flag.Usage = flagsUsage()
 	flag.Parse()

--- a/config/getters.go
+++ b/config/getters.go
@@ -71,6 +71,21 @@ func (c Config) LogFormat() string {
 	}
 }
 
+// ResultsOutput specifies whether the results summary is composed of a single
+// comma-separated line of records for a query, or whether the records are
+// returned one per line.
+func (c Config) ResultsOutput() string {
+
+	switch {
+	case c.cliConfig.ResultsOutput != "":
+		return c.cliConfig.ResultsOutput
+	case c.fileConfig.ResultsOutput != "":
+		return c.fileConfig.ResultsOutput
+	default:
+		return defaultResultsOutput
+	}
+}
+
 // ShowVersion returns the user-provided choice of displaying the application
 // version and exiting or the default value for this choice.
 func (c Config) ShowVersion() bool {

--- a/config/validate.go
+++ b/config/validate.go
@@ -128,6 +128,15 @@ func (c Config) Validate() error {
 	}
 	log.Debugf("c.LogFormat() validates: %#v", c.LogFormat())
 
+	switch c.ResultsOutput() {
+	case ResultsOutputSingleLine:
+	case ResultsOutputMultiLine:
+	default:
+		return fmt.Errorf("invalid option %q provided for results summary output",
+			c.ResultsOutput())
+	}
+	log.Debugf("c.ResultsOutput() validates: %#v", c.ResultsOutput())
+
 	// Optimist
 	log.Debug("All validation checks pass")
 	return nil

--- a/doc.go
+++ b/doc.go
@@ -32,6 +32,10 @@ FEATURES
 
 • User configurable logging format
 
+• User configurable results summary output format
+
+• User configurable query timeout
+
 USAGE
 
 See the README for examples.

--- a/dqrs/constants.go
+++ b/dqrs/constants.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/dnsc
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package dqrs
+
+// defaultDNSPort is the default UDP and TCP port used for incoming DNS
+// requests
+const defaultDNSPort = "53"
+
+// Supported Request types
+// TODO: Duplicated in config package
+const (
+	RequestTypeA       string = "A"
+	RequestTypeAAAA    string = "AAAA"
+	RequestTypeCNAME   string = "CNAME"
+	RequestTypeMX      string = "MX"
+	RequestTypePTR     string = "PTR"
+	RequestTypeSRV     string = "SRV"
+	RequestTypeUnknown string = "UNKNOWN"
+)
+
+const recordValueUnknown string = "type unknown"
+
+// Results summary output display options
+// TODO: Duplicated in config package
+const (
+	ResultsOutputSingleLine string = "single-line"
+	ResultsOutputMultiLine  string = "multi-line"
+)

--- a/dqrs/doc.go
+++ b/dqrs/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/dnsc
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Package dqrs provides types and functions used by this application to
+// collect and process DNS queries and responses.
+package dqrs

--- a/dqrs/record.go
+++ b/dqrs/record.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/dnsc
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package dqrs
+
+// DNSRecord represents a record returned as part of a query response.
+type DNSRecord struct {
+
+	// Value represents the record value such as smtp1.example.com.
+	Value string
+
+	// Type is the record type, such as A, MX or CNAME.
+	Type string
+
+	// TTL is the lifetime of the record, such as 300.
+	TTL uint32
+}


### PR DESCRIPTION
Set multi-line summary output display as the default with
the option to switch back to the previous display format.

- Config file setting support ("persistent" display setting)
- Flag support (one-off override)

Doc updates have been applied to reflect the new default
output summary display format, including the addition of
one example that uses the previous display format. This example
attempts to illustrate what the new multi-line output format
is attempting to solve.

fixes GH-146