### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,12 +24,19 @@ linters:
     - depguard
     - prealloc
     - misspell
-    - maligned
     - dupl
     - unconvert
     - gofmt
     - golint
     - gocritic
-    - scopelint
+    - exportloopref
     - govet
     - staticcheck
+
+  disable:
+    - maligned
+
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment


### PR DESCRIPTION
- replace deprecated `maligned` linter with
  `govet: fieldalignment`
- replace deprecated `scopelint` linter with
  `exportloopref`

fixes GH-153