### PR TITLE
golangci-lint | Replace golint linter with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - dupl
     - unconvert
     - gofmt
-    - golint
+    - revive
     - gocritic
     - exportloopref
     - govet


### PR DESCRIPTION
Recent version of golangci-lint has marked the `golint` linter as deprecated, recommends switching to `revive`.

fixes GH-173