### PR TITLE
Fix linting error: omit type from var declaration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Overridden via Makefile for release builds
-var version string = "dev build"
+var version = "dev build"
 
 // ErrVersionRequested indicates that the user requested application version
 // information.


### PR DESCRIPTION
As noted, we are allowing the type to be inferred from the right-hand side of the assignment.

fixes GH-176