### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/config/file.go
+++ b/config/file.go
@@ -32,6 +32,10 @@ func (c *Config) loadConfigFile(configFile string) (bool, error) {
 		return false, err
 	}
 	log.Debug("Config file opened")
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := fh.Close(); err != nil {
 			// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0.
gosec was updated in that version from v2.8.1 to v2.9.1.

fixes atc0005/dnsc#202
refs golangci/golangci-lint#2299