### PR TITLE
Refresh GHAWs: expand linting, switch to GHCR

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -20,8 +20,21 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Don't flag the whole workflow as failed if "experimental" matrix jobs
+    # fail. This allows the unstable image linting tasks to fail without
+    # marking the oldstable and stable image linting jobs as failed.
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      # Don't stop all workflow jobs if the unstable image linting tasks fail.
+      fail-fast: false
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable"]
+        experimental: [false]
+        include:
+          - container-image: "go-ci-unstable"
+            experimental: true
     container:
-      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Check out code
@@ -52,7 +65,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Check out code
@@ -71,7 +84,7 @@ jobs:
         container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
 
     container:
-      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+      image: "ghcr.io/atc0005/go-ci:${{ matrix.container-image}}"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -22,7 +22,8 @@ jobs:
     # Default: 360 minutes
     timeout-minutes: 10
     container:
-      image: "index.docker.io/golang:latest"
+      # Use (lightly touched) mirror of current "vanilla" upstream golang image
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Print go version
@@ -58,7 +59,8 @@ jobs:
     # Default: 360 minutes
     timeout-minutes: 10
     container:
-      image: "index.docker.io/golang:latest"
+      # Use (lightly touched) mirror of current "vanilla" upstream golang image
+      image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 
     steps:
       - name: Print go version

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+      image: ghcr.io/atc0005/go-ci:go-ci-lint-only
 
     steps:
       - name: Check out code

--- a/.github/workflows/lint-docker-files.yml
+++ b/.github/workflows/lint-docker-files.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     container:
-      image: index.docker.io/hadolint/hadolint:latest-debian
+      image: ghcr.io/hadolint/hadolint:latest-debian
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## EXPAND LINTING TO USE UNSTABLE & OLDSTABLE CONTAINERS

Use the same matrix of containers for linting in the `Validate
Codebase` GHAW that we're already using for testing and building jobs.

This applies the minimum linting requirements in addition to testing
"unstable" linting options that may become the new baseline in the
future.

One notable difference is that out of the matrix of containers used
for linting we mark the unstable container as "experimental" and
configure the job to ignore linting errors generated by that
container. This effectively makes any linting output from the unstable
container informational only as intended.

## SWITCH DOCKER IMAGE SOURCE

Switch out images from Docker Hub to Git Hub Container Registry
(GHCR).

## REFERENCES

- fixes GH-221
- fixes GH-222