### PR TITLE
Add support for querying NS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Submit query against a list of DNS servers and display summary of results
   - [Flags only, no config file](#flags-only-no-config-file)
   - [Use config file for DNS servers list and query types](#use-config-file-for-dns-servers-list-and-query-types)
   - [Specify DNS servers list via flags](#specify-dns-servers-list-via-flags)
+  - [Query nameserver record (NS)](#query-nameserver-record-ns)
   - [Query pointer record (PTR) using IP Address](#query-pointer-record-ptr-using-ip-address)
   - [Query server record (SRV)](#query-server-record-srv)
   - [Query server record (SRV) using SRV protocol keyword (aka, "shortcut")](#query-server-record-srv-using-srv-protocol-keyword-aka-shortcut)
@@ -180,6 +181,7 @@ These are the record types currently supported:
 - `A`
 - `AAAA`
 - `MX`
+- `NS`
 - `PTR`
 - `SRV`
 
@@ -292,6 +294,7 @@ dns_query_types = [
     "A",
     "AAAA",
     "MX",
+    "NS",
     "CNAME",
 ]
 
@@ -460,6 +463,25 @@ Server            RTT     Query            Query Type    Answer                 
 
 No errors here since www.yahoo.com had records for all of the requested query
 types.
+
+### Query nameserver record (NS)
+
+Here we query the Google Public DNS server 8.8.8.8 for the nameserver (NS)
+records for the google.com domain.
+
+```console
+$ dnsc --ds 8.8.8.8 -q google.com -t ns
+
+
+Server     RTT     Query         Type    Answer             Answer Type    TTL
+---        ---     ---           ---     ---                ---            ---
+8.8.8.8    77ms    google.com    NS      ns3.google.com.    NS             21600
+8.8.8.8    77ms    google.com    NS      ns2.google.com.    NS             21600
+8.8.8.8    77ms    google.com    NS      ns4.google.com.    NS             21600
+8.8.8.8    77ms    google.com    NS      ns1.google.com.    NS             21600
+
+Query Performed: 2022-06-01T06:30:32-05:00
+```
 
 ### Query pointer record (PTR) using IP Address
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -39,6 +39,13 @@ dns_query_types = [
     "A",
     "AAAA",
     "MX",
+
+    # This type is not commonly requested, so commented out by default.
+    # Submitting a query of this type returns all available nameservers for
+    # the requested domain.
+    #
+    # "NS",
+
     "CNAME",
 
     # This type expects the query string to be in IP Address format, which is

--- a/config/config.go
+++ b/config/config.go
@@ -100,6 +100,7 @@ const (
 	RequestTypeAAAA  string = "AAAA"
 	RequestTypeCNAME string = "CNAME"
 	RequestTypeMX    string = "MX"
+	RequestTypeNS    string = "NS"
 	RequestTypePTR   string = "PTR"
 	RequestTypeSRV   string = "SRV"
 )

--- a/config/validate.go
+++ b/config/validate.go
@@ -46,6 +46,7 @@ func (c Config) Validate() error {
 		case RequestTypeA:
 		case RequestTypeAAAA:
 		case RequestTypeCNAME:
+		case RequestTypeNS:
 		case RequestTypeMX:
 		case RequestTypePTR:
 		case RequestTypeSRV:

--- a/dqrs/constants.go
+++ b/dqrs/constants.go
@@ -18,6 +18,7 @@ const (
 	RequestTypeAAAA    string = "AAAA"
 	RequestTypeCNAME   string = "CNAME"
 	RequestTypeMX      string = "MX"
+	RequestTypeNS      string = "NS"
 	RequestTypePTR     string = "PTR"
 	RequestTypeSRV     string = "SRV"
 	RequestTypeUnknown string = "UNKNOWN"

--- a/dqrs/queryresponse.go
+++ b/dqrs/queryresponse.go
@@ -142,6 +142,9 @@ func (dqr DNSQueryResponse) Records() []DNSRecord {
 		case *dns.MX:
 			recordVal = v.Mx
 			recordType = RequestTypeMX
+		case *dns.NS:
+			recordVal = v.Ns
+			recordType = RequestTypeNS
 		case *dns.PTR:
 			recordVal = v.Ptr
 			recordType = RequestTypePTR


### PR DESCRIPTION
The support is already provided by the underlying library that
this project uses, so only minor changes are needed to permit
NS record queries.

NOTE: Future refactoring is needed to remove duplication between
constants in the dqrs package and the config package.

fixes GH-249