### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/config/config.go
+++ b/config/config.go
@@ -114,7 +114,8 @@ const (
 	SrvProtocolSIP        string = "sip"
 )
 
-// 	apex/log Handlers
+// apex/log Handlers
+//
 // ---------------------------------------------------------
 // cli - human-friendly CLI output
 // discard - discards all logs

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -1,14 +1,13 @@
 /*
-
 Submit query against a list of DNS servers and display summary of results
 
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/dnsc) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# Purpose
 
 Run a DNS query concurrently against all servers in a list and provide summary
 of results. This is most useful after moving servers between subnets when an
@@ -20,26 +19,18 @@ Command-line flags are supported for all options, though for some settings
 (e.g., DNS servers), specifying values via configuration file is easier for
 repeat use.
 
-FEATURES
+# Features
 
-• single binary, no outside dependencies
+  - single binary, no outside dependencies
+  - Multiple query types supported
+  - (Optional) SRV record protocol "shortcuts" for more complex queries
+  - User configurable logging levels
+  - User configurable logging format
+  - User configurable results summary output format
+  - User configurable query timeout
 
-• Multiple query types supported
-
-• (Optional) SRV record protocol "shortcuts" for more complex queries
-
-• User configurable logging levels
-
-• User configurable logging format
-
-• User configurable results summary output format
-
-• User configurable query timeout
-
-USAGE
+# Usage
 
 See the README for examples.
-
-
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/atc0005/dnsc
 
-go 1.17
+go 1.19
 
 require (
 	github.com/apex/log v1.9.0


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series