### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,10 @@ const (
 	resultsOutputFlagHelp  = "Specifies whether the results summary output is composed of a single comma-separated line of records for a query, or whether the records are returned one per line."
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Default flag settings if not overridden by user input
 const (
 	defaultLogLevel              string = "info"

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -19,40 +19,40 @@ func (c *Config) handleFlagsConfig() {
 
 	log.Debugf("Before parsing flags: %v", c.String())
 
-	flag.Var(&c.cliConfig.Servers, "ds", dnsServerFlagHelp+" (shorthand)")
+	flag.Var(&c.cliConfig.Servers, "ds", dnsServerFlagHelp+shorthandFlagSuffix)
 	flag.Var(&c.cliConfig.Servers, "dns-server", dnsServerFlagHelp)
 
-	flag.Var(&c.cliConfig.QueryTypes, "t", dnsRequestTypeFlagHelp+" (shorthand)")
+	flag.Var(&c.cliConfig.QueryTypes, "t", dnsRequestTypeFlagHelp+shorthandFlagSuffix)
 	flag.Var(&c.cliConfig.QueryTypes, "type", dnsRequestTypeFlagHelp)
 
-	flag.IntVar(&c.cliConfig.Timeout, "to", defaultTimeout, dnsTimeoutFlagHelp+" (shorthand)")
+	flag.IntVar(&c.cliConfig.Timeout, "to", defaultTimeout, dnsTimeoutFlagHelp+shorthandFlagSuffix)
 	flag.IntVar(&c.cliConfig.Timeout, "timeout", defaultTimeout, dnsTimeoutFlagHelp)
 
-	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+" (shorthand)")
+	flag.StringVar(&c.configFile, "cf", defaultConfigFile, configFileFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.configFile, "config-file", defaultConfigFile, configFileFlagHelp)
 
 	flag.BoolVar(&c.showVersion, "version", defaultDisplayVersionAndExit, versionFlagHelp)
-	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.showVersion, "v", defaultDisplayVersionAndExit, versionFlagHelp+shorthandFlagSuffix)
 
 	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "dns-errors-fatal", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp)
-	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "def", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.cliConfig.DNSErrorsFatal, "def", defaultDNSErrorsFatal, dnsErrorsFatalFlagHelp+shorthandFlagSuffix)
 
 	flag.BoolVar(&c.cliConfig.OmitTimestamp, "omit-timestamp", defaultOmitTimestamp, omitTimestampFlagHelp)
-	flag.BoolVar(&c.cliConfig.OmitTimestamp, "ot", defaultOmitTimestamp, omitTimestampFlagHelp+" (shorthand)")
+	flag.BoolVar(&c.cliConfig.OmitTimestamp, "ot", defaultOmitTimestamp, omitTimestampFlagHelp+shorthandFlagSuffix)
 
 	flag.StringVar(&c.cliConfig.Query, "query", defaultQuery, queryFlagHelp)
-	flag.StringVar(&c.cliConfig.Query, "q", defaultQuery, queryFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.Query, "q", defaultQuery, queryFlagHelp+shorthandFlagSuffix)
 
 	flag.Var(&c.cliConfig.SrvProtocols, "srv-protocol", srvProtocolFlagHelp)
-	flag.Var(&c.cliConfig.SrvProtocols, "sp", srvProtocolFlagHelp+" (shorthand)")
+	flag.Var(&c.cliConfig.SrvProtocols, "sp", srvProtocolFlagHelp+shorthandFlagSuffix)
 
-	flag.StringVar(&c.cliConfig.LogLevel, "ll", defaultLogLevel, logLevelFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.LogLevel, "ll", defaultLogLevel, logLevelFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.cliConfig.LogLevel, "log-level", defaultLogLevel, logLevelFlagHelp)
 
-	flag.StringVar(&c.cliConfig.LogFormat, "lf", defaultLogFormat, logFormatFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.LogFormat, "lf", defaultLogFormat, logFormatFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.cliConfig.LogFormat, "log-format", defaultLogFormat, logFormatFlagHelp)
 
-	flag.StringVar(&c.cliConfig.ResultsOutput, "ro", defaultResultsOutput, resultsOutputFlagHelp+" (shorthand)")
+	flag.StringVar(&c.cliConfig.ResultsOutput, "ro", defaultResultsOutput, resultsOutputFlagHelp+shorthandFlagSuffix)
 	flag.StringVar(&c.cliConfig.ResultsOutput, "results-output", defaultResultsOutput, resultsOutputFlagHelp)
 
 	flag.Usage = flagsUsage()


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.