### PR TITLE
Remove inactive maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
     - unconvert
 
   disable:
-    - maligned
 
 linters-settings:
   govet:


### PR DESCRIPTION
This linter has been deprecated for a while with the suggestion
to use govet 'fieldalignment'.

As of a recent release the linter no longer produced a report.

As of the v1.59.0 release attempting to use this linter produces an error.
