### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -304,7 +304,7 @@ func (c Config) String() string {
 
 // Branding is responsible for emitting application name, version and origin
 func Branding() {
-	fmt.Fprintf(flag.CommandLine.Output(), "\n%s %s\n%s\n\n", myAppName, version, myAppURL)
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "\n%s %s\n%s\n\n", myAppName, version, myAppURL)
 }
 
 // flagsUsage displays branding information and general usage details
@@ -316,7 +316,7 @@ func flagsUsage() func() {
 
 		Branding()
 
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s\":\n",
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of \"%s\":\n",
 			myBinaryName,
 		)
 		flag.PrintDefaults()

--- a/internal/dqrs/summary.go
+++ b/internal/dqrs/summary.go
@@ -26,7 +26,7 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 
 	// Add some lead-in spacing to better separate any earlier log messages from
 	// summary output
-	fmt.Fprintf(w, "\n\n")
+	_, _ = fmt.Fprintf(w, "\n\n")
 
 	// REMINDER: Column cells must be tab-terminated, not tab-separated:
 	// non-tab terminated trailing text at the end of a line forms a cell but
@@ -61,10 +61,10 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 	}
 
 	// Header row in output
-	fmt.Fprintln(w, headerRowTmpl)
+	_, _ = fmt.Fprintln(w, headerRowTmpl)
 
 	// Separator row
-	fmt.Fprintln(w, separatorRowTmpl)
+	_, _ = fmt.Fprintln(w, separatorRowTmpl)
 
 	for _, item := range dqrs {
 		// Building with `go build -gcflags=all=-d=loopvar=2` identified this
@@ -84,7 +84,7 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 		// if any errors were recorded when querying DNS server show those
 		// instead of attempting to show real results
 		if item.QueryError != nil {
-			fmt.Fprintf(w,
+			_, _ = fmt.Fprintf(w,
 				recordRowErrorTmpl,
 				item.Server,
 				item.ResponseTime.Round(time.Millisecond),
@@ -102,7 +102,7 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 		case ResultsOutputMultiLine:
 
 			for _, record := range item.Records() {
-				fmt.Fprintf(w,
+				_, _ = fmt.Fprintf(w,
 					recordRowSuccessTmpl,
 					item.Server,
 					item.ResponseTime.Round(time.Millisecond),
@@ -132,7 +132,7 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 				ttls = append(ttls, fmt.Sprint(record.TTL))
 			}
 
-			fmt.Fprintf(w,
+			_, _ = fmt.Fprintf(w,
 				recordRowSuccessTmpl,
 				item.Server,
 				item.ResponseTime.Round(time.Millisecond),
@@ -146,14 +146,14 @@ func (dqrs DNSQueryResponses) PrintSummary(outputFormat string, omitTimestamp bo
 	}
 
 	if !omitTimestamp {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"\nQuery Performed: %v",
 			time.Now().Format(time.RFC3339),
 		)
 	}
 
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 
 	if err := w.Flush(); err != nil {
 		log.Errorf("Error flushing tabwriter: %v", err.Error())


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
